### PR TITLE
Allow RequestTransformer to derive obj and act parameters from HttpRequest

### DIFF
--- a/samples/WebApplicationSample/CasbinConfigs/basic_policy.csv
+++ b/samples/WebApplicationSample/CasbinConfigs/basic_policy.csv
@@ -1,1 +1,8 @@
+# Policy below will only match using both BasicRequestTransformer and CustomRequestTransformer
 p, alice@example.com, BasicTest, Get
+
+# Policy below will only match if using the CustomRequestTransformer
+p, alice@example.com, /attribtest, GET
+
+# Policy below will only match if using the CustomRequestTransformer
+#p, alice@example.com, /home/privacy, GET

--- a/samples/WebApplicationSample/Controllers/ApiController.cs
+++ b/samples/WebApplicationSample/Controllers/ApiController.cs
@@ -4,10 +4,11 @@ using Microsoft.AspNetCore.Mvc;
 namespace WebApplicationSample.Controllers
 {
     [ApiController]
+    [Route("/api")]
     public class ApiController : Controller
     {
 
-        [HttpGet]
+        [HttpGet("index")]
         [CasbinAuthorize]
         public IActionResult Index()
         {

--- a/samples/WebApplicationSample/Controllers/HomeController.cs
+++ b/samples/WebApplicationSample/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using Casbin.AspNetCore.Authorization;
+using Casbin.AspNetCore.Authorization.Transformers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.Extensions.Logging;
@@ -17,6 +18,13 @@ namespace WebApplicationSample.Controllers
         }
 
         public IActionResult Index()
+        {
+            return View();
+        }
+
+        [HttpGet("attribtest")]
+        [CasbinAuthorize]
+        public IActionResult AttribRouteTest(string tenantId)
         {
             return View();
         }

--- a/samples/WebApplicationSample/Startup.cs
+++ b/samples/WebApplicationSample/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.IO;
 using System.Security.Claims;
+using Casbin.AspNetCore.Authorization.Transformers;
 
 namespace WebApplicationSample
 {
@@ -40,6 +41,10 @@ namespace WebApplicationSample
                 options.PreferSubClaimType = ClaimTypes.Name;
                 options.DefaultModelPath = Path.Combine("CasbinConfigs", "basic_model.conf");
                 options.DefaultPolicyPath = Path.Combine("CasbinConfigs", "basic_policy.csv");
+
+                // Comment line below to use the default BasicRequestTransformer
+                // Note: Commenting the line means that the action methods MUST have [CasbinAuthorize()] attribute which explicitly specifies obj and policy. Otherwise authorization will be denied
+                options.DefaultRequestTransformer = new CustomRequestTransformer();
             });
         }
 

--- a/samples/WebApplicationSample/Views/Home/AttribRouteTest.cshtml
+++ b/samples/WebApplicationSample/Views/Home/AttribRouteTest.cshtml
@@ -1,0 +1,8 @@
+﻿@{
+    ViewData["Title"] = "Attribute Routed Test Page";
+}
+
+<div class="text-center">
+    <h1 class="display-4">Welcome</h1>
+    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+</div>

--- a/samples/WebApplicationSample/Views/Home/Index.cshtml
+++ b/samples/WebApplicationSample/Views/Home/Index.cshtml
@@ -4,5 +4,6 @@
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
-    <p>Basic Model : Policy is "p, alice@example.com, Index, Get" - <a asp-controller="Home" asp-action="BasicTest">Test</a>.</p>
+    <p>Basic Model : Policy is "p, alice@example.com, BasicTest, GET" - <a asp-controller="Home" asp-action="BasicTest">Test</a>.</p>
+    <p>Attrib Route : Policy is "p, alice@example.com, /attribtest, GET" - <a asp-controller="Home" asp-action="AttribRouteTest">Attribute Route Test</a>.</p>
 </div>

--- a/src/Casbin.AspNetCore.Astractions/Casbin.AspNetCore.Abstractions.csproj
+++ b/src/Casbin.AspNetCore.Astractions/Casbin.AspNetCore.Abstractions.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   

--- a/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationContext.cs
+++ b/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 namespace Casbin.AspNetCore.Authorization
 {
@@ -7,5 +8,6 @@ namespace Casbin.AspNetCore.Authorization
     {
         public ClaimsPrincipal User { get; }
         public IEnumerable<ICasbinAuthorizationData> AuthorizationData { get; }
+        public HttpRequest? Request { get; }
     }
 }

--- a/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationContextFactory.cs
+++ b/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationContextFactory.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 namespace Casbin.AspNetCore.Authorization
 {
     public interface ICasbinAuthorizationContextFactory
     {
-        public ICasbinAuthorizationContext CreateContext(ClaimsPrincipal user, ICasbinAuthorizationData data);
+        public ICasbinAuthorizationContext CreateContext(ClaimsPrincipal user, ICasbinAuthorizationData data,   HttpRequest? request = null);
 
-        public ICasbinAuthorizationContext CreateContext(ClaimsPrincipal user, IEnumerable<ICasbinAuthorizationData> data);
+        public ICasbinAuthorizationContext CreateContext(ClaimsPrincipal user, IEnumerable<ICasbinAuthorizationData> data, HttpRequest? request = null);
     }
 }

--- a/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationData.cs
+++ b/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationData.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Net;
+using System.Net.Cache;
+using Microsoft.AspNetCore.Http;
 
 namespace Casbin.AspNetCore.Authorization
 {

--- a/src/Casbin.AspNetCore.Core/Casbin.AspNetCore.Core.csproj
+++ b/src/Casbin.AspNetCore.Core/Casbin.AspNetCore.Core.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Casbin.NET" Version="1.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
   </ItemGroup>
 

--- a/src/Casbin.AspNetCore.Core/CasbinAuthorizationContext.cs
+++ b/src/Casbin.AspNetCore.Core/CasbinAuthorizationContext.cs
@@ -1,22 +1,27 @@
 ﻿using System.Collections.Generic;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 namespace Casbin.AspNetCore.Authorization
 {
     public class CasbinAuthorizationContext : ICasbinAuthorizationContext
     {
-        public CasbinAuthorizationContext(ClaimsPrincipal user, ICasbinAuthorizationData data)
-            : this(user, new[]{ data })
+        public CasbinAuthorizationContext(ClaimsPrincipal user, ICasbinAuthorizationData data, HttpRequest? request = null)
+            : this(user, new[]{ data }, request)
         {
         }
 
-        public CasbinAuthorizationContext(ClaimsPrincipal user, IEnumerable<ICasbinAuthorizationData> data)
+        public CasbinAuthorizationContext(ClaimsPrincipal user, IEnumerable<ICasbinAuthorizationData> data, HttpRequest? request = null)
         {
             User = user;
             AuthorizationData = data;
+            Request = request;
         }
 
         public ClaimsPrincipal User { get; }
         public IEnumerable<ICasbinAuthorizationData> AuthorizationData { get; }
+
+        public HttpRequest? Request { get; }
+
     }
 }

--- a/src/Casbin.AspNetCore.Core/DefaultCasbinAuthorizationContextFactory.cs
+++ b/src/Casbin.AspNetCore.Core/DefaultCasbinAuthorizationContextFactory.cs
@@ -1,16 +1,17 @@
 ﻿using System.Collections.Generic;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 
 namespace Casbin.AspNetCore.Authorization
 {
     public class DefaultCasbinAuthorizationContextFactory : ICasbinAuthorizationContextFactory
     {
         public ICasbinAuthorizationContext CreateContext(
-            ClaimsPrincipal user, ICasbinAuthorizationData data)
-            => new CasbinAuthorizationContext(user, data);
+            ClaimsPrincipal user, ICasbinAuthorizationData data, HttpRequest? request = null)
+            => new CasbinAuthorizationContext(user, data, request);
 
         public ICasbinAuthorizationContext CreateContext(
-            ClaimsPrincipal user, IEnumerable<ICasbinAuthorizationData> data)
-            => new CasbinAuthorizationContext(user, data);
+            ClaimsPrincipal user, IEnumerable<ICasbinAuthorizationData> data, HttpRequest? request = null)
+            => new CasbinAuthorizationContext(user, data, request);
     }
 }

--- a/src/Casbin.AspNetCore.Core/Transformers/CustomRequestTransformer.cs
+++ b/src/Casbin.AspNetCore.Core/Transformers/CustomRequestTransformer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Casbin.AspNetCore.Authorization.Transformers
+{
+    public class CustomRequestTransformer : IRequestTransformer
+    {
+        public string? Issuer { get; set; }
+        public string? PreferSubClaimType { get; set; } = ClaimTypes.NameIdentifier;
+
+        public virtual ValueTask<IEnumerable<object>> TransformAsync(ICasbinAuthorizationContext context, ICasbinAuthorizationData data)
+        {
+            var requestValues = new object[3];
+            requestValues[0] = SubTransform(context, data);
+            requestValues[1] = ObjTransform(context, data);
+            requestValues[2] = ActTransform(context, data);
+            return new ValueTask<IEnumerable<object>>(requestValues);
+        }
+
+        public virtual string SubTransform(ICasbinAuthorizationContext context, ICasbinAuthorizationData data)
+        {
+            Claim? claim;
+            if (Issuer is null)
+            {
+                claim = context.User.FindFirst(PreferSubClaimType);
+                return claim is null ? string.Empty : claim.Value;
+            }
+
+            claim = context.User.FindAll(PreferSubClaimType).FirstOrDefault(
+                c => string.Equals(c.Issuer, Issuer));
+            return claim is null ? string.Empty : claim.Value;
+        }
+
+        public virtual string ObjTransform(ICasbinAuthorizationContext context, ICasbinAuthorizationData data)
+        {
+            var request = context?.Request;
+            if (request == null)
+            {
+                throw new Exception("Missing HttpRequest in CasbinAuthorizationContext");
+            }
+            return data.Value1 ?? request.Path.Value?.ToLowerInvariant() ?? string.Empty;
+        }
+            
+        public virtual string ActTransform(ICasbinAuthorizationContext context, ICasbinAuthorizationData data)
+        {
+            var request = context?.Request;
+            if (request == null)
+            {
+                throw new Exception("Missing HttpRequest in CasbinAuthorizationContext");
+            }
+            return data.Value2 ?? request.Method ?? string.Empty;
+        }
+    }
+}

--- a/src/Casbin.AspNetCore/Casbin.AspNetCore.csproj
+++ b/src/Casbin.AspNetCore/Casbin.AspNetCore.csproj
@@ -25,6 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Casbin.AspNetCore.Core\Casbin.AspNetCore.Core.csproj" />
   </ItemGroup>
 

--- a/src/Casbin.AspNetCore/CasbinAuthorizationMiddleware.cs
+++ b/src/Casbin.AspNetCore/CasbinAuthorizationMiddleware.cs
@@ -51,6 +51,7 @@ namespace Casbin.AspNetCore.Authorization
                 return;
             }
 
+
             // Policy evaluator has transient lifetime so it fetched from request services instead of injecting in constructor
             var policyEvaluator = context.RequestServices.GetRequiredService<IPolicyEvaluator>();
 
@@ -74,7 +75,7 @@ namespace Casbin.AspNetCore.Authorization
                 resource = context;
             }
 
-            var casbinContext = context.RequestServices.GetRequiredService<ICasbinAuthorizationContextFactory>().CreateContext(context.User, authorizeData);
+            var casbinContext = context.RequestServices.GetRequiredService<ICasbinAuthorizationContextFactory>().CreateContext(context.User, authorizeData, context.Request);
 
             var authorizeResult = await context.RequestServices.GetRequiredService<ICasbinEvaluator>().AuthorizeAsync(policy, authenticateResult, context, casbinContext, resource);
 


### PR DESCRIPTION
Fix: https://github.com/casbin-net/casbin-aspnetcore/issues/18

The CasbinAuthorizationContext has a new property HttpRequest which can be used by RequestTransformers to extract/derive authorization data. There is also a CustomRequestTransformer and matching policy which show how this can be done. The CustomRequestTransformer can potentially replace the BasicRequestTransformer since it is a superset and supports both providing obj and act in the CasbinAuthorize attribute, and deriving them from HttpRequest

