### PR TITLE
feat: Sync authorization data with Casbin2.x generics.

### DIFF
--- a/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationData.cs
+++ b/src/Casbin.AspNetCore.Astractions/ICasbinAuthorizationData.cs
@@ -1,19 +1,11 @@
 ﻿using System;
-using System.Net;
-using System.Net.Cache;
-using Microsoft.AspNetCore.Http;
+using Casbin.Model;
 
 namespace Casbin.AspNetCore.Authorization
 {
     public interface ICasbinAuthorizationData
     {
-        public string Value1 { get; }
-        public string Value2 { get; }
-        public string Value3 { get; }
-        public string Value4 { get; }
-        public string Value5 { get; }
-        public string[]? CustomValues { get; }
-        public int ValueCount { get; }
+        IRequestValues? Values { get; }
         public string? Issuer { get; set; }
         public string? PreferSubClaimType { get; set; }
         public Type? RequestTransformerType { get; set; }

--- a/src/Casbin.AspNetCore.Astractions/ICustomizedAutorizationDataAdapter.cs
+++ b/src/Casbin.AspNetCore.Astractions/ICustomizedAutorizationDataAdapter.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Casbin.AspNetCore.Authorization
+{
+    public interface ICustomizedAuthorizationDataAdapter
+    {
+        public ValueTask<IEnumerable<object>> ExecuteAsync(ICasbinAuthorizationContext context, ICasbinAuthorizationData data);
+    }
+}

--- a/src/Casbin.AspNetCore.Astractions/IRequestTransformer.cs
+++ b/src/Casbin.AspNetCore.Astractions/IRequestTransformer.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Casbin.Model;
 
 namespace Casbin.AspNetCore.Authorization
 {
@@ -7,6 +7,6 @@ namespace Casbin.AspNetCore.Authorization
     {
         public string? Issuer { get; set; }
         public string PreferSubClaimType { get; set; }
-        public ValueTask<IEnumerable<object>> TransformAsync(ICasbinAuthorizationContext context, ICasbinAuthorizationData data);
+        public ValueTask<IRequestValues> TransformAsync(ICasbinAuthorizationContext context, IRequestValues data);
     }
 }

--- a/src/Casbin.AspNetCore.Core/Attributes/CasbinAuthorizeAttribute.cs
+++ b/src/Casbin.AspNetCore.Core/Attributes/CasbinAuthorizeAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Casbin.Model;
 
 namespace Casbin.AspNetCore.Authorization
 {
@@ -13,76 +14,59 @@ namespace Casbin.AspNetCore.Authorization
         /// </summary>
         public CasbinAuthorizeAttribute()
         {
-            ValueCount = 0;
+            
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CasbinAuthorizeAttribute"/> class. 
         /// </summary>
-        public CasbinAuthorizeAttribute(string value1)
+        public CasbinAuthorizeAttribute(params string[] values)
         {
-            Value1 = value1;
-            ValueCount++;
+            Values = values.Length switch
+            {
+                1 => Request.Create<string>(values[0]),
+                2 => Request.Create<string, string>(values[0], values[1]),
+                3 => Request.Create<string, string, string>(values[0], values[1], values[2]),
+                4 => Request.Create<string, string, string, string>(
+                    values[0], values[1], values[2], values[3]
+                    ),
+                5 => Request.Create<string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4]
+                    ),
+                6 => Request.Create<string, string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4], 
+                    values[5]
+                    ),
+                7 => Request.Create<string, string, string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4], 
+                    values[5], values[6]
+                    ),
+                8 => Request.Create<string, string, string, string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4], 
+                    values[5], values[6], values[7]),
+                9 => Request.Create<string, string, string, string, string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4], 
+                    values[5], values[6], values[7], values[8]
+                    ),
+                10 => Request.Create<string, string, string, string, string, string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4], 
+                    values[5], values[6], values[7], values[8], values[9]
+                    ),
+                11 => Request.Create<string, string, string, string, string, string, string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4], 
+                    values[5], values[6], values[7], values[8], values[9], 
+                    values[10]
+                    ),
+                12 => Request.Create<string, string, string, string, string, string, string, string, string, string, string, string>(
+                    values[0], values[1], values[2], values[3], values[4], 
+                    values[5], values[6], values[7], values[8], values[9], 
+                    values[10], values[11]
+                    ),
+                _ => throw new ArgumentException("Invalid value count to create a request.")
+            };
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CasbinAuthorizeAttribute"/> class. 
-        /// </summary>
-        public CasbinAuthorizeAttribute(string value1, string value2)
-            : this(value1)
-        {
-            Value2 = value2;
-            ValueCount++;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CasbinAuthorizeAttribute"/> class. 
-        /// </summary>
-        public CasbinAuthorizeAttribute(string value1, string value2, string value3)
-            : this(value1, value2)
-        {
-            Value3 = value3;
-            ValueCount++;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CasbinAuthorizeAttribute"/> class. 
-        /// </summary>
-        public CasbinAuthorizeAttribute(string value1, string value2, string value3, string value4)
-            : this(value1, value2, value3)
-        {
-            Value4 = value4;
-            ValueCount++;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CasbinAuthorizeAttribute"/> class. 
-        /// </summary>
-        public CasbinAuthorizeAttribute(string value1, string value2, string value3, string value4, string value5)
-            : this(value1, value2, value3, value4)
-        {
-            Value5 = value5;
-            ValueCount++;
-        }
-
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CasbinAuthorizeAttribute"/> class. 
-        /// </summary>
-        public CasbinAuthorizeAttribute(string value1, string value2, string value3, string value4, string value5, params string[] customValues)
-            : this(value1, value2, value3, value4, value5)
-        {
-            CustomValues = customValues;
-            ValueCount += CustomValues.Length;
-        }
-
-        public string Value1 { get; } = string.Empty;
-        public string Value2 { get; } = string.Empty;
-        public string Value3 { get; } = string.Empty;
-        public string Value4 { get; } = string.Empty;
-        public string Value5 { get; } = string.Empty;
-        public string[]? CustomValues { get; }
-        public int ValueCount { get; }
+        public IRequestValues? Values { get; }
         public string? Issuer { get; set; }
         public string? PreferSubClaimType { get; set; }
         public Type? RequestTransformerType { get; set; }

--- a/src/Casbin.AspNetCore.Core/DefaultEnforcerService.cs
+++ b/src/Casbin.AspNetCore.Core/DefaultEnforcerService.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Casbin.AspNetCore.Authorization.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Casbin.Extensions;
 
 namespace Casbin.AspNetCore.Authorization
 {
@@ -32,7 +31,7 @@ namespace Casbin.AspNetCore.Authorization
             var enforcer = _enforcerProvider.GetEnforcer();
             if (enforcer is null)
             {
-                throw new ArgumentException("Can not find any enforcer.");
+                throw new ArgumentException("Cannot find any enforcer.");
             }
 
             var transformersArray =
@@ -42,7 +41,7 @@ namespace Casbin.AspNetCore.Authorization
             bool noDefault = _options.Value.DefaultRequestTransformer is null;
             if (transformersArray is null || transformersArray.Length == 0 && noDefault)
             {
-                throw new ArgumentException("Can find any request transformer.");
+                throw new ArgumentException("Cannot find any request transformer.");
             }
 
             foreach (var data in context.AuthorizationData)
@@ -59,7 +58,7 @@ namespace Casbin.AspNetCore.Authorization
 
                     if (transformer is null)
                     {
-                        throw new ArgumentException("Can find any specified type request transformer.", nameof(data.RequestTransformerType));
+                        throw new ArgumentException("Cannot find any specified type request transformer.", nameof(data.RequestTransformerType));
                     }
                 }
                 else if (!noDefault)
@@ -71,7 +70,7 @@ namespace Casbin.AspNetCore.Authorization
 
                 if (transformer is null)
                 {
-                    throw new ArgumentException("Can find any request transformer.", nameof(_transformersCache.Transformers));
+                    throw new ArgumentException("Cannot find any request transformer.", nameof(_transformersCache.Transformers));
                 }
 
                 // The order of deciding transformer.PreferSubClaimType is :
@@ -84,9 +83,12 @@ namespace Casbin.AspNetCore.Authorization
                 // 2. null (if this issuer is null, it will be ignored)
                 transformer.Issuer = data.Issuer;
 
-                var requestValues = await transformer.TransformAsync(context, data);
-
-                if (await enforcer.EnforceAsync(requestValues as object[] ?? requestValues.ToArray()))
+                if(data.Values is null)
+                {
+                    throw new ArgumentException("Cannot find any request value.");
+                }
+                var requestValues = await transformer.TransformAsync(context, data.Values);
+                if(await enforcer.EnforceAsync(requestValues))
                 {
                     _logger.CasbinAuthorizationSucceeded();
                     continue;

--- a/src/Casbin.AspNetCore.Core/Extensions/EnforcerExtension.cs
+++ b/src/Casbin.AspNetCore.Core/Extensions/EnforcerExtension.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using Casbin.Model;
+
+namespace Casbin.AspNetCore.Authorization.Extensions
+{
+    public static class EnforcerExtension
+    {
+        public static async Task<bool> EnforceFromAuthorizationDataAsync(this IEnforcer enforcer, IRequestValues requestValues)
+        {
+            return requestValues.Count switch
+            {
+                1 => await enforcer.EnforceAsync<string>(requestValues[0]),
+                2 => await enforcer.EnforceAsync<string, string>(requestValues[0], requestValues[1]),
+                3 => await enforcer.EnforceAsync<string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2]
+                    ),
+                4 => await enforcer.EnforceAsync<string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2], requestValues[3]
+                    ),
+                5 => await enforcer.EnforceAsync<string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2],
+                    requestValues[3], requestValues[4]
+                    ),
+                6 => await enforcer.EnforceAsync<string, string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2],
+                    requestValues[3], requestValues[4], requestValues[5]
+                    ),
+                7 => await enforcer.EnforceAsync<string, string, string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2], requestValues[3],
+                    requestValues[4], requestValues[5], requestValues[6]
+                    ),
+                8 => await enforcer.EnforceAsync<string, string, string, string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2], requestValues[3],
+                    requestValues[4], requestValues[5], requestValues[6], requestValues[7]
+                    ),
+                9 => await enforcer.EnforceAsync<string, string, string, string, string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2],
+                    requestValues[3], requestValues[4], requestValues[5],
+                    requestValues[6], requestValues[7], requestValues[8]
+                    ),
+                10 => await enforcer.EnforceAsync<string, string, string, string, string, string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2], requestValues[3],
+                    requestValues[4], requestValues[5], requestValues[6], requestValues[7],
+                    requestValues[8], requestValues[9]
+                    ),
+                11 => await enforcer.EnforceAsync<string, string, string, string, string, string, string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2], requestValues[3],
+                    requestValues[4], requestValues[5], requestValues[6], requestValues[7],
+                    requestValues[8], requestValues[9], requestValues[10]
+                    ),
+                12 => await enforcer.EnforceAsync<string, string, string, string, string, string, string, string, string, string, string, string>(
+                    requestValues[0], requestValues[1], requestValues[2], requestValues[3],
+                    requestValues[4], requestValues[5], requestValues[6], requestValues[7],
+                    requestValues[8], requestValues[9], requestValues[10], requestValues[11]
+                    ),
+                _ => throw new ArgumentException("Invalid request value count.")
+            };
+        }
+    }
+}

--- a/src/Casbin.AspNetCore.Core/Transformers/KeyMatchRequestTransformer.cs
+++ b/src/Casbin.AspNetCore.Core/Transformers/KeyMatchRequestTransformer.cs
@@ -1,20 +1,21 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Casbin.Model;
+using Casbin.AspNetCore.Authorization.Extensions;
+using System;
 
 namespace Casbin.AspNetCore.Authorization.Transformers
 {
     public class KeyMatchRequestTransformer : BasicRequestTransformer
     {
-        public override ValueTask<IEnumerable<object>> TransformAsync(ICasbinAuthorizationContext context, ICasbinAuthorizationData data)
+        public override ValueTask<IRequestValues> TransformAsync(ICasbinAuthorizationContext context, IRequestValues data)
         {
-            object[] requestValues = new object[3];
-            requestValues[0] = SubTransform(context, data);
-
-            requestValues[1] = ObjTransform(context, data, (c, _) =>
+            var sub = SubTransform(context, data);
+            var obj = ObjTransform(context, data, (c, _) =>
                     c.HttpContext.Request.Path);
-            requestValues[2] = ActTransform(context, data, (c, _) =>
+            var act = ActTransform(context, data, (c, _) =>
                     c.HttpContext.Request.Method);
-            return new ValueTask<IEnumerable<object>>(requestValues);
+
+            return new ValueTask<IRequestValues>(Request.Create<string, string, string>(sub, obj, act));
         }
     }
 }

--- a/src/Casbin.AspNetCore.Core/Transformers/RequestTransformer.cs
+++ b/src/Casbin.AspNetCore.Core/Transformers/RequestTransformer.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
+using Casbin.Model;
 
 namespace Casbin.AspNetCore.Authorization.Transformers
 {
@@ -11,53 +9,14 @@ namespace Casbin.AspNetCore.Authorization.Transformers
         public virtual string? Issuer { get; set; }
         public virtual string PreferSubClaimType { get; set; } = string.Empty;
 
-        public virtual ValueTask<IEnumerable<object>> TransformAsync(ICasbinAuthorizationContext context, ICasbinAuthorizationData data)
+        public virtual ValueTask<IRequestValues> TransformAsync(ICasbinAuthorizationContext context, IRequestValues data)
         {
-            if (data.ValueCount is 0)
+            if (data.Count == 0)
             {
                 throw new ArgumentException("Value count is invalid.");
             }
 
-            object[]? requestValues = new object[data.ValueCount];
-            int requestValuesLength = requestValues.Length;
-
-            if (requestValuesLength > 0)
-            {
-                requestValues[0] = data.Value1;
-            }
-            if (requestValuesLength > 1)
-            {
-                requestValues[1] = data.Value2;
-            }
-            if (requestValuesLength > 2)
-            {
-                requestValues[2] = data.Value3;
-            }
-            if (requestValuesLength > 3)
-            {
-                requestValues[3] = data.Value4;
-            }
-            if (requestValuesLength > 4)
-            {
-                requestValues[4] = data.Value5;
-            }
-            if (requestValuesLength <= 5)
-            {
-                return new ValueTask<IEnumerable<object>>(requestValues);
-            }
-
-            // Add the custom values
-            if (data.CustomValues is null)
-            {
-                throw new ArgumentException("Value count is invalid.");
-            }
-
-            string[]? customValues = data.CustomValues;
-            for (int index = 0; index < customValues.Length; index++)
-            {
-                requestValues[4 + index] = customValues[index];
-            }
-            return new ValueTask<IEnumerable<object>>(requestValues);
+            return new ValueTask<IRequestValues>(data);
         }
     }
 }

--- a/test/Casbin.AspNetCore.Tests/RequestTransformerTest.cs
+++ b/test/Casbin.AspNetCore.Tests/RequestTransformerTest.cs
@@ -6,6 +6,7 @@ using Casbin.AspNetCore.Authorization;
 using Casbin.AspNetCore.Authorization.Transformers;
 using Casbin.AspNetCore.Tests.Extensions;
 using Casbin.AspNetCore.Tests.Utilities;
+using Casbin.Model;
 using Xunit;
 
 namespace Casbin.AspNetCore.Tests
@@ -43,7 +44,7 @@ namespace Casbin.AspNetCore.Tests
                 new CasbinAuthorizeAttribute(resource, action), httpContext);
 
             // Act
-            object[] requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First())).ToArray();
+            IRequestValues requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First().Values));
 
             // Assert
             Assert.Equal(userNameExpected, requestValues[0]);
@@ -84,7 +85,7 @@ namespace Casbin.AspNetCore.Tests
                 new CasbinAuthorizeAttribute(resource, action), httpContext);
 
             // Act
-            object[] requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First())).ToArray();
+            IRequestValues requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First().Values));
 
             // Assert
             Assert.Equal(userNameExpected, requestValues[0]);
@@ -126,7 +127,7 @@ namespace Casbin.AspNetCore.Tests
                 new CasbinAuthorizeAttribute(resource, action), httpContext);
 
             // Act
-            object[] requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First())).ToArray();
+            IRequestValues requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First().Values));
 
             // Assert
             Assert.Equal(userNameExpected, requestValues[0]);
@@ -167,7 +168,7 @@ namespace Casbin.AspNetCore.Tests
                 new CasbinAuthorizeAttribute(resource, action), httpContext);
 
             // Act
-            object[] requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First())).ToArray();
+            IRequestValues requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First().Values));
 
             // Assert
             Assert.Equal(userNameExpected, requestValues[0]);
@@ -208,7 +209,7 @@ namespace Casbin.AspNetCore.Tests
                 new CasbinAuthorizeAttribute(resource, action), httpContext);
 
             // Act
-            object[] requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First())).ToArray();
+            IRequestValues requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First().Values));
 
             // Assert
             Assert.Equal(userNameExpected, requestValues[0]);
@@ -251,7 +252,7 @@ namespace Casbin.AspNetCore.Tests
                 new CasbinAuthorizeAttribute(resource, action), httpContext);
 
             // Act
-            object[] requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First())).ToArray();
+            IRequestValues requestValues = (await transformer.TransformAsync(casbinContext, casbinContext.AuthorizationData.First().Values));
 
             // Assert
             Assert.Equal(userNameExpected, requestValues[0]);


### PR DESCRIPTION
1. Limit the output of Transformer to ```string[]```.
2. Add adapter for customized authorization data to process customized data type.
3. Use generics API of enforcer of Casbin 2.x when no customized data is applied.